### PR TITLE
Changed netgen/setup patches, colab spice, and CVC power filename

### DIFF
--- a/TO_202504.ipynb
+++ b/TO_202504.ipynb
@@ -127,7 +127,15 @@
         "rm -rf $PDK_ROOT\n",
         "ciel enable --pdk $PDK $PDK_COMMIT\n",
         "# patch for mimcap and antenna error in netgen setup file from pdk\n",
-        "sed -i.bak '/lsearch .cells2/,/circuit2/s/circuit1 .dev/circuit2 $dev/' $PDK_ROOT/$PDK/libs.tech/netgen/ihp-sg13g2_setup.tcl\n",
+        "# patch to remove permute for npn devices.\n",
+        "# patch to remove parallel combination of bipolar devices. parallel devices with matching parameters will be combined during magic extraction.\n",
+        "# patch to change cap_rfcmim to rfcmim.\n",
+        "# patch to remove wfeed parameter from source capacitors because magic does not extract it.\n",
+        "sed -i.bak -e '/lsearch .cells2/,/circuit2/s/circuit1 .dev/circuit2 $dev/' \\\n",
+        "  -e '/npn13/,/circuit2.*delete/s/.*permute/#&/' \\\n",
+        "  -e '/npn13/,/circuit2.*delete/s/.*parallel/#&/' \\\n",
+        "  -e 's/cap_rfcmim/rfcmim/' \\\n",
+        "  -e '/rfcmim/,/circuit2.*delete/s/.*circuit2.*delete.*/& wfeed/' $PDK_ROOT/$PDK/libs.tech/netgen/ihp-sg13g2_setup.tcl\n",
         "\n",
         "# allow met7 text to be recognized on pads\n",
         "sed -i.bak -e '/labels PADID/a\\\n",
@@ -332,15 +340,6 @@
     {
       "cell_type": "markdown",
       "source": [
-        "Create the modified magic source netlist."
-      ],
-      "metadata": {
-        "id": "hp5bC4b8px17"
-      }
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
         "Create lvs_config.json and update the LVS_SPICE_FILES and LVS_VERILOG_FILES for every design.\n",
         "\n",
         "Update the other parameters as needed."
@@ -419,7 +418,7 @@
         "CVC_REPORT_FILE = $WORK_ROOT/cvc.log\n",
         "EOF\n",
         "\n",
-        "cat > $WORK_ROOT/cvc.power.$LAYOUT_TOP <<EOF\n",
+        "cat > $WORK_ROOT/cvc.power.$PROJECT  <<EOF\n",
         "GND power 0.0\n",
         "VCC power 3.3\n",
         "EOF"
@@ -501,8 +500,7 @@
         "export LAYOUT_TOP=FDM_QNC_00_LN_TIA\n",
         "export GDSFILE=design_data/gds/FMD_QNC_00_40_GHz_Low_Noise_TIA.mod.gds\n",
         "export WORK_ROOT=$DATA_ROOT/$PROJECT/work/$PROJECT\n",
-        "# export SPICE_FILE=$CHECK_ROOT/$MPW/$PROJECT/xschem/lvs/$PROJECT.spice\n",
-        "export SPICE_FILE=$WORK_ROOT/$PROJECT.spice\n",
+        "export SPICE_FILE=$CHECK_ROOT/$MPW/$PROJECT/xschem/lvs/$PROJECT.spice\n",
         "export KLAYOUT_CDL=$WORK_ROOT/$LAYOUT_TOP.cdl\n",
         "EOF\n",
         "cat $DATA_ROOT/project_env\n",
@@ -515,46 +513,6 @@
       ],
       "metadata": {
         "id": "ABoKEu8eRKT0"
-      },
-      "execution_count": null,
-      "outputs": []
-    },
-    {
-      "cell_type": "markdown",
-      "source": [
-        "Create the modified magic source netlist."
-      ],
-      "metadata": {
-        "id": "yhcZTjYxRKT0"
-      }
-    },
-    {
-      "cell_type": "code",
-      "source": [
-        "%%shell\n",
-        "cat /content/env\n",
-        "source /content/env\n",
-        "cat > $SPICE_FILE <<EOF\n",
-        "** sch_path: /home/shr25031/ihp-mpw-be/ihp-mpw-be/TO_Apr2025/40_GHZ_LOW_NOISE_TIA/xschem/40_GHZ_LOW_NOISE_TIA.sch\n",
-        ".subckt 40_GHZ_LOW_NOISE_TIA RFIN GND VCC1 VCC2 RFOUT VCC3\n",
-        "*.PININFO RFIN:I GND:B VCC1:B VCC2:B RFOUT:O VCC3:B\n",
-        "XQq1 net1 RFIN GND GND npn13G2 le=900e-9 we=70.0n m=10\n",
-        "XCc1 VCC1 GND cap_cmim w=30.0e-6 l=60.0e-6 m=2\n",
-        "XQq2 VCC2 net1 net2 GND npn13G2 le=900e-9 we=70.0n m=5\n",
-        "XCc2 VCC2 GND cap_cmim w=30.0e-6 l=60.0e-6 m=2\n",
-        "XRRE2 net2 GND rppd w=3.0e-6 l=6.0e-6 m=1 b=0\n",
-        "XRRC1 VCC1 net1 rppd w=8.0e-6 l=4.5e-6 m=1 b=0\n",
-        "XQq3 RFOUT net2 net3 GND npn13G2 le=900e-9 we=70.0n m=10\n",
-        "XRRF RFIN net2 rppd w=2.0e-6 l=6.5e-6 m=1 b=0\n",
-        "XRRE3 net3 GND rsil w=4.0e-6 l=3.0e-6 m=1 b=0\n",
-        "XRRC3 VCC3 RFOUT rsil w=4.0e-6 l=14.5e-6 m=1 b=0\n",
-        "XCc3 VCC3 GND cap_cmim w=30.0e-6 l=60.0e-6 m=2\n",
-        ".ends\n",
-        "\n",
-        "EOF"
-      ],
-      "metadata": {
-        "id": "VHIIf0YTRKT1"
       },
       "execution_count": null,
       "outputs": []
@@ -644,7 +602,7 @@
         "CVC_REPORT_FILE = $WORK_ROOT/cvc.log\n",
         "EOF\n",
         "\n",
-        "cat > $WORK_ROOT/cvc.power.$LAYOUT_TOP <<EOF\n",
+        "cat > $WORK_ROOT/cvc.power.$PROJECT <<EOF\n",
         "GND power 0.0\n",
         "VCC* power 3.3\n",
         "EOF"


### PR DESCRIPTION
netgen setup patches:
- delete permute terminals for npn, pnp
- delete parallel reduction for npn, pnp
- change cap_rfcmim to rfcim Since spice files are now generated from xschem, inline spice file cell deleted CVC execution is based on the existence of a power file suffixed with top source name. The top source name was changed to the project name, but the CVC power file was suffixed with the top layout name. This commit corrects that for 160GHz and 40GHz designs.